### PR TITLE
HTTP status code rule support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ venv/bin/python:
 install: venv/bin/python
 	venv/bin/python setup.py install
 
+.PHONY: format
+format: 
+	venv/bin/black -t py37 -t py38 -t py39 -t py310 -t py311 -t py312 .
+
 .PHONY: check
 check: test lint
 

--- a/rulesengine_client/client.py
+++ b/rulesengine_client/client.py
@@ -12,82 +12,86 @@ class Client(object):
     def __init__(self, host, datasource):
         self.host = host
         self.datasource = datasource
-        self._log = logging.getLogger(
-            '{0.__module__}'.format(Client))
+        self._log = logging.getLogger("{0.__module__}".format(Client))
 
     def get_rules(self):
-        response = requests.get('{}/rules'.format(self.host))
+        response = requests.get("{}/rules".format(self.host))
         return Response(response)
 
     def create_rule(self, rule_dict):
-        response = requests.post('{}/rules'.format(self.host), data=rule_dict)
+        response = requests.post("{}/rules".format(self.host), data=rule_dict)
         return Response(response)
 
     def get_rule(self, rule_id):
-        response = requests.get('{}/rule/{}'.format(self.host, rule_id))
+        response = requests.get("{}/rule/{}".format(self.host, rule_id))
         return Response(response)
 
     def update_rule(self, rule_id, rule_dict):
-        response = requests.put(
-            '{}/rule/{}'.format(self.host, rule_id), data=rule_dict)
+        response = requests.put("{}/rule/{}".format(self.host, rule_id), data=rule_dict)
         return Response(response)
 
     def delete_rule(self, rule_id):
-        response = requests.delete('{}/rule/{}'.format(self.host, rule_id))
+        response = requests.delete("{}/rule/{}".format(self.host, rule_id))
         return Response(response)
 
     def tree_for_surt(self, surt):
-        response = requests.get('{}/rules/tree/{}'.format(self.host, surt))
+        response = requests.get("{}/rules/tree/{}".format(self.host, surt))
         return Response(response)
 
-    def rules_for_request(self, surt, capture_date, neg_surt=None,
-                          collection=None, partner=None):
+    def rules_for_request(
+        self, surt, capture_date, neg_surt=None, collection=None, partner=None
+    ):
         p = {
-            'surt': surt,
+            "surt": surt,
         }
         if capture_date is not None:
-            p['capture-date'] = capture_date
+            p["capture-date"] = capture_date
         if neg_surt is not None:
-            p['neg-surt'] = neg_surt
+            p["neg-surt"] = neg_surt
         if collection is not None:
-            p['collection'] = collection
+            p["collection"] = collection
         if partner is not None:
-            p['partner'] = partner
-        response = requests.get(
-            '{}/rules/for-request'.format(self.host), params=p)
+            p["partner"] = partner
+        response = requests.get("{}/rules/for-request".format(self.host), params=p)
         return Response(response)
 
-    def rules_from_postgres(self, surt, capture_date, neg_surt=None,
-                            collection=None, partner=None):
-        query_start = 'SELECT * from rules_rule where %s like surt and enabled = true'
+    def rules_from_postgres(
+        self, surt, capture_date, neg_surt=None, collection=None, partner=None
+    ):
+        query_start = "SELECT * from rules_rule where %s like surt and enabled = true"
         if collection:
             query_end = " and (collection = %s or (collection = '' and partner = ''));"
             who = collection
         elif partner:
             query_end = " and (partner = %s or (collection = '' and partner = ''));"
             who = partner
-        else: # all endpoint
+        else:  # all endpoint
             query_end = " and (collection = '' and partner = '');"
             who = None
-        rules_query = f'{query_start}{query_end}'
+        rules_query = f"{query_start}{query_end}"
         try:
-            conn = psycopg2.connect(self.datasource,
-                    cursor_factory=extras.DictCursor)
+            conn = psycopg2.connect(self.datasource, cursor_factory=extras.DictCursor)
         except Exception as e:
-            self._log.warning(f'db connection failure: {e}')
+            self._log.warning(f"db connection failure: {e}")
             return None
         cur = conn.cursor()
         try:
             if collection or partner:
-                cur.execute(rules_query, (surt, who, ))
+                cur.execute(
+                    rules_query,
+                    (
+                        surt,
+                        who,
+                    ),
+                )
             else:
-                cur.execute(rules_query, (surt, ))
+                cur.execute(rules_query, (surt,))
         except Exception as e:
-            self._log.warning(f'exception querying for {surt} and {who}: {e}')
+            self._log.warning(f"exception querying for {surt} and {who}: {e}")
             return None
         rules = cur.fetchall()
         if rules:
-            self._log.debug('returning {}...'.format(rules[0]))
+            self._log.debug("returning {}...".format(rules[0]))
         else:
-            self._log.debug('no rules returned')
+            self._log.debug("no rules returned")
         return RuleCollection.from_pg_response(rules)

--- a/rulesengine_client/exceptions.py
+++ b/rulesengine_client/exceptions.py
@@ -1,11 +1,12 @@
 from wayback.cdxserver import BlockedException
 
+
 class MalformedResponseException(Exception):
     pass
 
+
 class BlockWithMessageException(BlockedException):
-    error_header = (
-        "BlockWithMessageException: Blocked Site Error"
-        )
+    error_header = "BlockWithMessageException: Blocked Site Error"
+
     def __init__(self, block_reason="unknown"):
         self.block_reason = block_reason

--- a/rulesengine_client/models.py
+++ b/rulesengine_client/models.py
@@ -156,7 +156,7 @@ class Rule(object):
 
     def applies(self, warc_name, capture_date, client_ip=None,
                 retrieve_date=datetime.now(tz=utc), protocol=None,
-                subdomain=None, server_side_filters=True):
+                subdomain=None, status_code=None, server_side_filters=True):
         """Checks to see whether a rule applies given request and playback
         information.
 
@@ -166,6 +166,7 @@ class Rule(object):
         :param bytes timestamp capture_date: the date of the requested capture.
         :param str protocol: the protocol of the capture.
         :param str subdomain: the subdomain of the capture.
+        :param str status_code: the HTTP status code of the requested capture.
         :param bool server_side_filters: whether or not filters have already
             been run server side. This includes capture and retrieval dates,
             collection, and partner.
@@ -184,7 +185,9 @@ class Rule(object):
             self.retrieve_date_applies(retrieve_date) and
             self.warc_match_applies(warc_name) and
             self.subdomain_applies(subdomain) and
-            self.protocol_applies(protocol))
+            self.protocol_applies(protocol) and
+            self.status_code_applies(status_code)
+        )
 
     def ip_range_applies(self, client_ip):
         """Checks to see whether the rule applies based on the client's IP
@@ -237,6 +240,19 @@ class Rule(object):
         if self.subdomain is None:
             return True
         return self.subdomain == subdomain
+
+    def status_code_applies(self, status_code):
+        """Check to see whether the rule applies based on the HTTP status code.
+
+        :param status_code: the query's HTTP status code
+        :type status_code: int
+
+        :return: True if the rule defines no status_code , or rule status_code
+        matches param status_code, otherwise False.
+        """
+        if self.status_code is None:
+            return True
+        return self.status_code == status_code
 
     def seconds_since_capture_applies(self, capture_date):
         """Checks to see whether the rule applies based on the date of
@@ -337,7 +353,7 @@ class RuleCollection(object):
 
     def filter_applicable_rules(self, warc_name, client_ip=None, capture_date=None,
                                 retrieve_date=datetime.now(tz=utc),
-                                protocol=None, subdomain=None,
+                                protocol=None, subdomain=None, status_code=None,
                                 server_side_filters=True):
         """Filters the rules to only those which apply to the request.
 
@@ -351,6 +367,7 @@ class RuleCollection(object):
         :param bytes timestamp capture_date: the date of the requested capture.
         :param str protocol: the protocol of the capture.
         :param str subdomain: the subdomain of the capture.
+        :param str status_code: the HTTP status code of the capture.
         :param bool server_side_filters: whether or not filters have already
             been run server side. This includes capture and retrieval dates,
             collection, and partner.
@@ -360,6 +377,7 @@ class RuleCollection(object):
             capture_date=capture_date,
             protocol=protocol,
             subdomain=subdomain,
+            status_code=status_code,
             server_side_filters=server_side_filters)])
         applicable_rules.sort_rules()
         return applicable_rules

--- a/rulesengine_client/models.py
+++ b/rulesengine_client/models.py
@@ -16,15 +16,32 @@ from .exceptions import MalformedResponseException, BlockWithMessageException
 re2_options = re.Options()
 re2_options.encoding = re.Options.Encoding.LATIN1
 
+
 class Rule(object):
     """Rule represents a rule received from the rulesengine server."""
 
-    def __init__(self, surt, policy, neg_surt=None, capture_date=None,
-                 retrieve_date=None, ip_range=None, seconds_since_capture=None,
-                 collection=None, partner=None, protocol=None, subdomain=None,
-                 status_code=None, warc_match=None, rewrite_from=None, rewrite_to=None,
-                 private_comment=None, public_comment=None, enabled=True,
-                 environment='prod'):
+    def __init__(
+        self,
+        surt,
+        policy,
+        neg_surt=None,
+        capture_date=None,
+        retrieve_date=None,
+        ip_range=None,
+        seconds_since_capture=None,
+        collection=None,
+        partner=None,
+        protocol=None,
+        subdomain=None,
+        status_code=None,
+        warc_match=None,
+        rewrite_from=None,
+        rewrite_to=None,
+        private_comment=None,
+        public_comment=None,
+        enabled=True,
+        environment="prod",
+    ):
         self.surt = surt
         self.policy = policy
         self.neg_surt = neg_surt
@@ -41,27 +58,34 @@ class Rule(object):
         self.public_comment = public_comment
         self.enabled = enabled
         self.environment = environment
-        self._log = logging.getLogger(
-            '{0.__module__}'.format(Rule))
+        self._log = logging.getLogger("{0.__module__}".format(Rule))
 
         # Parse dates out of capture and retrieval date fields if necessary.
         # We compare capture date to a bytes timestamp from a cdx record.
-        self.capture_date = {
-            'start': capture_date['start'] if capture_date['start'] else None,
-            'end':   capture_date['end']   if capture_date['end']   else None
-        } if capture_date else None
+        self.capture_date = (
+            {
+                "start": capture_date["start"] if capture_date["start"] else None,
+                "end": capture_date["end"] if capture_date["end"] else None,
+            }
+            if capture_date
+            else None
+        )
 
         # We compare retrieve_date only to datetime.
-        self.retrieve_date = {
-            'start': retrieve_date['start'] if retrieve_date['start'] else None,
-            'end':   retrieve_date['end']   if retrieve_date['end']   else None
-        } if retrieve_date else None
+        self.retrieve_date = (
+            {
+                "start": retrieve_date["start"] if retrieve_date["start"] else None,
+                "end": retrieve_date["end"] if retrieve_date["end"] else None,
+            }
+            if retrieve_date
+            else None
+        )
 
         # Parse IP addresses if necessary. note: ip checks disabled 202107
-        if (ip_range and ip_range['start'] and ip_range['end']):
+        if ip_range and ip_range["start"] and ip_range["end"]:
             self.ip_range = {
-                'start': ipaddr.IPAddress(ip_range['start']),
-                'end': ipaddr.IPAddress(ip_range['end']),
+                "start": ipaddr.IPAddress(ip_range["start"]),
+                "end": ipaddr.IPAddress(ip_range["end"]),
             }
         else:
             self.ip_range = None
@@ -69,97 +93,109 @@ class Rule(object):
     @classmethod
     def from_response(cls, response):
         """Build a Rule from the results of a query to the server."""
-        if 'surt' not in response or 'policy' not in response:
+        if "surt" not in response or "policy" not in response:
             raise MalformedResponseException(
-                'rules must contain at least a surt and a policy')
-        if 'capture_date' in response:
-            capture_date = {'start': None, 'end': None}
-            if 'start' in response['capture_date']:
-                capture_date['start'] = response['capture_date']['start']
-            if 'end' in response['capture_date']:
-                capture_date['end'] = response['capture_date']['end']
+                "rules must contain at least a surt and a policy"
+            )
+        if "capture_date" in response:
+            capture_date = {"start": None, "end": None}
+            if "start" in response["capture_date"]:
+                capture_date["start"] = response["capture_date"]["start"]
+            if "end" in response["capture_date"]:
+                capture_date["end"] = response["capture_date"]["end"]
         else:
             capture_date = None
-        if 'retrieve_date' in response:
-            retrieve_date = {'start': None, 'end': None}
-            if 'start' in response['retrieve_date']:
-                retrieve_date['start'] = response['retrieve_date']['start']
-            if 'end' in response['retrieve_date']:
-                retrieve_date['end'] = response['retrieve_date']['end']
+        if "retrieve_date" in response:
+            retrieve_date = {"start": None, "end": None}
+            if "start" in response["retrieve_date"]:
+                retrieve_date["start"] = response["retrieve_date"]["start"]
+            if "end" in response["retrieve_date"]:
+                retrieve_date["end"] = response["retrieve_date"]["end"]
         else:
             retrieve_date = None
         return cls(
-            response['surt'],
-            response['policy'],
-            capture_date = capture_date,
-            retrieve_date = retrieve_date,
-            neg_surt=response.get('neg_surt'),
-            seconds_since_capture=response.get('seconds_since_capture'),
-            collection=response.get('collection'),
-            partner=response.get('partner'),
-            warc_match=response.get('warc_match'),
-            rewrite_from=response.get('rewrite_from'),
-            rewrite_to=response.get('rewrite_to'),
-            private_comment=response.get('private_comment'),
-            public_comment=response.get('public_comment'),
-            enabled=response.get('enabled'),
-            environment=response.get('environment'))
+            response["surt"],
+            response["policy"],
+            capture_date=capture_date,
+            retrieve_date=retrieve_date,
+            neg_surt=response.get("neg_surt"),
+            seconds_since_capture=response.get("seconds_since_capture"),
+            collection=response.get("collection"),
+            partner=response.get("partner"),
+            warc_match=response.get("warc_match"),
+            rewrite_from=response.get("rewrite_from"),
+            rewrite_to=response.get("rewrite_to"),
+            private_comment=response.get("private_comment"),
+            public_comment=response.get("public_comment"),
+            enabled=response.get("enabled"),
+            environment=response.get("environment"),
+        )
 
     @classmethod
     def from_pg_response(cls, response):
         """Build a Rule from the results of a query to postgres."""
-        if 'surt' not in response or 'policy' not in response:
+        if "surt" not in response or "policy" not in response:
             raise MalformedResponseException(
-                'rules must contain at least a surt and a policy')
-        capture_date = {'start': None, 'end': None}
-        if 'capture_date_start' in response and response['capture_date_start']:
-            capture_date['start'] = datetime2timestamp(response['capture_date_start'])
-        if 'capture_date_end' in response and response['capture_date_end']:
-            capture_date['end'] = datetime2timestamp(response['capture_date_end'])
-        if not capture_date['start'] and not capture_date['end']:
+                "rules must contain at least a surt and a policy"
+            )
+        capture_date = {"start": None, "end": None}
+        if "capture_date_start" in response and response["capture_date_start"]:
+            capture_date["start"] = datetime2timestamp(response["capture_date_start"])
+        if "capture_date_end" in response and response["capture_date_end"]:
+            capture_date["end"] = datetime2timestamp(response["capture_date_end"])
+        if not capture_date["start"] and not capture_date["end"]:
             capture_date = None
-        retrieve_date = {'start': None, 'end': None}
-        if 'retrieve_date_start' in response and response['retrieve_date_start']:
-            retrieve_date['start'] = response['retrieve_date_start']
-        if 'retrieve_date_end' in response and response['retrieve_date_end']:
-            retrieve_date['end'] = response['retrieve_date_end']
-        if not retrieve_date['start'] and not retrieve_date['end']:
+        retrieve_date = {"start": None, "end": None}
+        if "retrieve_date_start" in response and response["retrieve_date_start"]:
+            retrieve_date["start"] = response["retrieve_date_start"]
+        if "retrieve_date_end" in response and response["retrieve_date_end"]:
+            retrieve_date["end"] = response["retrieve_date_end"]
+        if not retrieve_date["start"] and not retrieve_date["end"]:
             retrieve_date = None
-        neg_surt=response.get('neg_surt')
-        seconds_since_capture=response.get('seconds_since_capture')
-        collection=response.get('collection')
-        partner=response.get('partner')
-        protocol=response.get('protocol')
-        status_code=response.get('status_code')
-        subdomain=response.get('subdomain')
-        warc_match=response.get('warc_match')
-        rewrite_from=response.get('rewrite_from')
-        rewrite_to=response.get('rewrite_to')
-        private_comment=response.get('private_comment')
-        public_comment=response.get('public_comment')
-        environment=response.get('environment')
+        neg_surt = response.get("neg_surt")
+        seconds_since_capture = response.get("seconds_since_capture")
+        collection = response.get("collection")
+        partner = response.get("partner")
+        protocol = response.get("protocol")
+        status_code = response.get("status_code")
+        subdomain = response.get("subdomain")
+        warc_match = response.get("warc_match")
+        rewrite_from = response.get("rewrite_from")
+        rewrite_to = response.get("rewrite_to")
+        private_comment = response.get("private_comment")
+        public_comment = response.get("public_comment")
+        environment = response.get("environment")
         return cls(
-            response['surt'],
-            response['policy'],
-            capture_date = capture_date,
-            retrieve_date = retrieve_date,
-            neg_surt = neg_surt if neg_surt else None,
-            seconds_since_capture = seconds_since_capture,
-            collection = collection if collection else None,
-            partner = partner if partner else None,
-            protocol = protocol if protocol else None,
-            status_code = status_code if status_code else None,
-            subdomain = subdomain if subdomain else None,
-            warc_match = warc_match.encode() if warc_match else None,
-            rewrite_from = rewrite_from.encode() if rewrite_from else None,
-            rewrite_to = rewrite_to.encode() if rewrite_to else None,
-            private_comment = private_comment,
-            public_comment = public_comment,
-            environment = environment)
+            response["surt"],
+            response["policy"],
+            capture_date=capture_date,
+            retrieve_date=retrieve_date,
+            neg_surt=neg_surt if neg_surt else None,
+            seconds_since_capture=seconds_since_capture,
+            collection=collection if collection else None,
+            partner=partner if partner else None,
+            protocol=protocol if protocol else None,
+            status_code=status_code if status_code else None,
+            subdomain=subdomain if subdomain else None,
+            warc_match=warc_match.encode() if warc_match else None,
+            rewrite_from=rewrite_from.encode() if rewrite_from else None,
+            rewrite_to=rewrite_to.encode() if rewrite_to else None,
+            private_comment=private_comment,
+            public_comment=public_comment,
+            environment=environment,
+        )
 
-    def applies(self, warc_name, capture_date, client_ip=None,
-                retrieve_date=datetime.now(tz=utc), protocol=None,
-                subdomain=None, status_code=None, server_side_filters=True):
+    def applies(
+        self,
+        warc_name,
+        capture_date,
+        client_ip=None,
+        retrieve_date=datetime.now(tz=utc),
+        protocol=None,
+        subdomain=None,
+        status_code=None,
+        server_side_filters=True,
+    ):
         """Checks to see whether a rule applies given request and playback
         information.
 
@@ -177,20 +213,22 @@ class Rule(object):
         :return: True if the rule applies to the request, otherwise False.
         """
         if server_side_filters:
-            return (self.warc_match_applies(warc_name) and
-                    self.protocol_applies(protocol) and
-                    self.status_code_applies(protocol) and
-                    self.subdomain_applies(subdomain) and
-                    self.seconds_since_capture_applies(capture_date))
+            return (
+                self.warc_match_applies(warc_name)
+                and self.protocol_applies(protocol)
+                and self.status_code_applies(protocol)
+                and self.subdomain_applies(subdomain)
+                and self.seconds_since_capture_applies(capture_date)
+            )
 
         return (
-            self.seconds_since_capture_applies(capture_date) and
-            self.capture_date_applies(capture_date) and
-            self.retrieve_date_applies(retrieve_date) and
-            self.warc_match_applies(warc_name) and
-            self.subdomain_applies(subdomain) and
-            self.protocol_applies(protocol) and
-            self.status_code_applies(status_code)
+            self.seconds_since_capture_applies(capture_date)
+            and self.capture_date_applies(capture_date)
+            and self.retrieve_date_applies(retrieve_date)
+            and self.warc_match_applies(warc_name)
+            and self.subdomain_applies(subdomain)
+            and self.protocol_applies(protocol)
+            and self.status_code_applies(status_code)
         )
 
     def ip_range_applies(self, client_ip):
@@ -210,8 +248,7 @@ class Rule(object):
             return True
         if isinstance(client_ip, str):
             client_ip = ipaddr.IPAddress(client_ip)
-        return (self.ip_range['start'] <= client_ip and
-                self.ip_range['end'] >= client_ip)
+        return self.ip_range["start"] <= client_ip and self.ip_range["end"] >= client_ip
 
     def protocol_applies(self, protocol):
         """Check to see whether the rule applies based on the query protocol.
@@ -272,8 +309,9 @@ class Rule(object):
         """
         if self.seconds_since_capture is None:
             return True
-        return (timedelta(seconds=int(self.seconds_since_capture)) >=
-                (datetime.now(tz=utc) - timestamp2datetime(capture_date).replace(tzinfo=utc)))
+        return timedelta(seconds=int(self.seconds_since_capture)) >= (
+            datetime.now(tz=utc) - timestamp2datetime(capture_date).replace(tzinfo=utc)
+        )
 
     def capture_date_applies(self, capture_date):
         """Checks to see whether the rule applies based on the date of
@@ -289,8 +327,9 @@ class Rule(object):
         """
         if not self.capture_date:
             return True
-        return ((not self.capture_date['start'] or self.capture_date['start'] <= capture_date) and
-                (not self.capture_date['end'] or self.capture_date['end'] >= capture_date))
+        return (
+            not self.capture_date["start"] or self.capture_date["start"] <= capture_date
+        ) and (not self.capture_date["end"] or self.capture_date["end"] >= capture_date)
 
     def retrieve_date_applies(self, retrieve_date=datetime.now(tz=utc)):
         """Checks to see whether the rule applies based on the date of
@@ -306,8 +345,12 @@ class Rule(object):
         """
         if not self.retrieve_date:
             return True
-        return ((not self.retrieve_date['start'] or self.retrieve_date['start'] <= retrieve_date) and
-                (not self.retrieve_date['end'] or self.retrieve_date['end'] >= retrieve_date))
+        return (
+            not self.retrieve_date["start"]
+            or self.retrieve_date["start"] <= retrieve_date
+        ) and (
+            not self.retrieve_date["end"] or self.retrieve_date["end"] >= retrieve_date
+        )
 
     def warc_match_applies(self, warc_name):
         """Checks to see whether the rule applies based on a regex of the WARC
@@ -326,14 +369,14 @@ class Rule(object):
 
         return self.partner == partner
 
+
 class RuleCollection(object):
     """RuleCollection represents a group of rules applying to a request."""
 
     def __init__(self, rules):
         self.rules = rules
         self.sort_rules()
-        self._log = logging.getLogger(
-            '{0.__module__}'.format(RuleCollection))
+        self._log = logging.getLogger("{0.__module__}".format(RuleCollection))
 
     @classmethod
     def from_response(cls, response):
@@ -355,10 +398,17 @@ class RuleCollection(object):
         """Sorts the rules on the surts."""
         self.rules.sort(key=lambda x: x.surt)
 
-    def filter_applicable_rules(self, warc_name, client_ip=None, capture_date=None,
-                                retrieve_date=datetime.now(tz=utc),
-                                protocol=None, subdomain=None, status_code=None,
-                                server_side_filters=True):
+    def filter_applicable_rules(
+        self,
+        warc_name,
+        client_ip=None,
+        capture_date=None,
+        retrieve_date=datetime.now(tz=utc),
+        protocol=None,
+        subdomain=None,
+        status_code=None,
+        server_side_filters=True,
+    ):
         """Filters the rules to only those which apply to the request.
 
         Before checking whether a request is allowed or applying any rewrites,
@@ -376,13 +426,20 @@ class RuleCollection(object):
             been run server side. This includes capture and retrieval dates,
             collection, and partner.
         """
-        applicable_rules = RuleCollection([rule for rule in self.rules if rule.applies(
-            warc_name,
-            capture_date=capture_date,
-            protocol=protocol,
-            subdomain=subdomain,
-            status_code=status_code,
-            server_side_filters=server_side_filters)])
+        applicable_rules = RuleCollection(
+            [
+                rule
+                for rule in self.rules
+                if rule.applies(
+                    warc_name,
+                    capture_date=capture_date,
+                    protocol=protocol,
+                    subdomain=subdomain,
+                    status_code=status_code,
+                    server_side_filters=server_side_filters,
+                )
+            ]
+        )
         applicable_rules.sort_rules()
         return applicable_rules
 
@@ -418,32 +475,38 @@ class RuleCollection(object):
         :return: A new RuleCollection with only rewrite rules.
         """
         return RuleCollection(
-            [rule for rule in self.rules if rule.policy.startswith('rewrite')])
+            [rule for rule in self.rules if rule.policy.startswith("rewrite")]
+        )
 
     def rewrite(self, response):
-        """ Rewrites response according to matching rewrite rules.
+        """Rewrites response according to matching rewrite rules.
 
         :return: rewritten response
         """
         headers_r = response.headers
         content_r = response.data
         for r in self.rules:
-            if r.policy == 'rewrite-headers':
+            if r.policy == "rewrite-headers":
                 #  is this bytes or string?
                 #  note: we're rewriting only "rewritable" mimetypes in wsgiapp.py
                 headers_r[r.rewrite_from] = r.rewrite_to
-            if r.policy == 'rewrite-all':
+            if r.policy == "rewrite-all":
                 try:
-                    content_r = re.sub(r.rewrite_from, r.rewrite_to, content_r, options=re2_options)
-                    self._log.info(f'rewriting response.data from... {r.rewrite_from[:80]}... to ...{r.rewrite_to[:80]}')
+                    content_r = re.sub(
+                        r.rewrite_from, r.rewrite_to, content_r, options=re2_options
+                    )
+                    self._log.info(
+                        f"rewriting response.data from... {r.rewrite_from[:80]}... to ...{r.rewrite_to[:80]}"
+                    )
                 except Exception as e:
-                    self._log.warn(f'exception rewriting response.data from {r.rewrite_from[:80]}: {e}')
+                    self._log.warn(
+                        f"exception rewriting response.data from {r.rewrite_from[:80]}: {e}"
+                    )
                     content_r = response.data
-            elif r.policy == 'rewrite-js':
-                self._log.warn(f'rulesengine policy rewrite-js to be implemented')
+            elif r.policy == "rewrite-js":
+                self._log.warn(f"rulesengine policy rewrite-js to be implemented")
                 # support this here?
                 continue
             else:
-                self._log.warn('unexpected policy; nothing rewritten!')
+                self._log.warn("unexpected policy; nothing rewritten!")
         return headers_r, content_r
-

--- a/rulesengine_client/models.py
+++ b/rulesengine_client/models.py
@@ -22,7 +22,7 @@ class Rule(object):
     def __init__(self, surt, policy, neg_surt=None, capture_date=None,
                  retrieve_date=None, ip_range=None, seconds_since_capture=None,
                  collection=None, partner=None, protocol=None, subdomain=None,
-                 warc_match=None, rewrite_from=None, rewrite_to=None,
+                 status_code=None, warc_match=None, rewrite_from=None, rewrite_to=None,
                  private_comment=None, public_comment=None, enabled=True,
                  environment='prod'):
         self.surt = surt
@@ -32,6 +32,7 @@ class Rule(object):
         self.collection = collection
         self.partner = partner
         self.protocol = protocol
+        self.status_code = status_code
         self.subdomain = subdomain
         self.warc_match = warc_match
         self.rewrite_from = rewrite_from
@@ -129,6 +130,7 @@ class Rule(object):
         collection=response.get('collection')
         partner=response.get('partner')
         protocol=response.get('protocol')
+        status_code=response.get('status_code')
         subdomain=response.get('subdomain')
         warc_match=response.get('warc_match')
         rewrite_from=response.get('rewrite_from')
@@ -146,6 +148,7 @@ class Rule(object):
             collection = collection if collection else None,
             partner = partner if partner else None,
             protocol = protocol if protocol else None,
+            status_code = status_code if status_code else None,
             subdomain = subdomain if subdomain else None,
             warc_match = warc_match.encode() if warc_match else None,
             rewrite_from = rewrite_from.encode() if rewrite_from else None,
@@ -176,6 +179,7 @@ class Rule(object):
         if server_side_filters:
             return (self.warc_match_applies(warc_name) and
                     self.protocol_applies(protocol) and
+                    self.status_code_applies(protocol) and
                     self.subdomain_applies(subdomain) and
                     self.seconds_since_capture_applies(capture_date))
 

--- a/rulesengine_client/response.py
+++ b/rulesengine_client/response.py
@@ -10,13 +10,14 @@ class Response(object):
             self.json = response.json()
         except ValueError:
             raise MalformedResponseException(
-                'received non-JSON response', response.body)
-        self.status = self.json['status']
-        self.message = self.json['message']
-        if 'result' in self.json:
-            self.result = self.json['result']
+                "received non-JSON response", response.body
+            )
+        self.status = self.json["status"]
+        self.message = self.json["message"]
+        if "result" in self.json:
+            self.result = self.json["result"]
         self.rules = None
-        if self.status == 'success':
+        if self.status == "success":
             self._parse_result()
 
     def _parse_result(self):
@@ -25,5 +26,4 @@ class Response(object):
         elif isinstance(self.result, dict):
             self.rules = RuleCollection.from_response([self.result])
         else:
-            raise MalformedResponseException(
-                'received unexpected result', self.result)
+            raise MalformedResponseException("received unexpected result", self.result)

--- a/rulesengine_client/tests/test_client.py
+++ b/rulesengine_client/tests/test_client.py
@@ -1,4 +1,5 @@
 import unittest
+
 try:
     from unittest.mock import (
         call,
@@ -16,111 +17,115 @@ from .test_response import StubResponse
 
 class ClientTestCase(unittest.TestCase):
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_get_rules(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
         result = c.get_rules()
         self.assertEqual(result.status_code, 200)
-        mock_request.assert_called_once_with('http://localhost/rules')
+        mock_request.assert_called_once_with("http://localhost/rules")
 
-    @patch('requests.post')
+    @patch("requests.post")
     def test_create_rule(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
         result = c.create_rule({})
         self.assertEqual(result.status_code, 200)
-        mock_request.assert_called_once_with('http://localhost/rules', data={})
+        mock_request.assert_called_once_with("http://localhost/rules", data={})
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_get_rule(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
         result = c.get_rule(1)
         self.assertEqual(result.status_code, 200)
-        mock_request.assert_called_once_with('http://localhost/rule/1')
+        mock_request.assert_called_once_with("http://localhost/rule/1")
 
-    @patch('requests.put')
+    @patch("requests.put")
     def test_update_rule(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
         result = c.update_rule(1, {})
         self.assertEqual(result.status_code, 200)
-        mock_request.assert_called_once_with(
-            'http://localhost/rule/1', data={})
+        mock_request.assert_called_once_with("http://localhost/rule/1", data={})
 
-    @patch('requests.delete')
+    @patch("requests.delete")
     def test_delete_rule(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
         result = c.delete_rule(1)
         self.assertEqual(result.status_code, 200)
-        mock_request.assert_called_once_with('http://localhost/rule/1')
+        mock_request.assert_called_once_with("http://localhost/rule/1")
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_tree_for_surt(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
-        result = c.tree_for_surt('http://(org,archive,)')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
+        result = c.tree_for_surt("http://(org,archive,)")
         self.assertEqual(result.status_code, 200)
         mock_request.assert_called_once_with(
-            'http://localhost/rules/tree/http://(org,archive,)')
+            "http://localhost/rules/tree/http://(org,archive,)"
+        )
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_rules_for_request(self, mock_request):
         mock_request.return_value = StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}')
-        c = Client('http://localhost', 'datasource')
-        result = c.rules_for_request('http://(org,archive,)', 'today')
+            200, '{"status": "success", "message": "ok", "result": []}'
+        )
+        c = Client("http://localhost", "datasource")
+        result = c.rules_for_request("http://(org,archive,)", "today")
         self.assertEqual(result.status_code, 200)
-        result = c.rules_for_request(
-            'http://(org,archive,)', 'today', neg_surt='foo')
+        result = c.rules_for_request("http://(org,archive,)", "today", neg_surt="foo")
         self.assertEqual(result.status_code, 200)
-        result = c.rules_for_request(
-            'http://(org,archive,)', 'today', collection='bar')
+        result = c.rules_for_request("http://(org,archive,)", "today", collection="bar")
         self.assertEqual(result.status_code, 200)
-        result = c.rules_for_request(
-            'http://(org,archive,)', 'today', partner='baz')
+        result = c.rules_for_request("http://(org,archive,)", "today", partner="baz")
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(mock_request.call_args_list, [
-            call(
-                'http://localhost/rules/for-request',
-                params={
-                    'surt': 'http://(org,archive,)',
-                    'capture-date': 'today',
-                }),
-            call(
-                'http://localhost/rules/for-request',
-                params={
-                    'surt': 'http://(org,archive,)',
-                    'capture-date': 'today',
-                    'neg-surt': 'foo',
-                }),
-            call(
-                'http://localhost/rules/for-request',
-                params={
-                    'surt': 'http://(org,archive,)',
-                    'capture-date': 'today',
-                    'collection': 'bar',
-                }),
-            call(
-                'http://localhost/rules/for-request',
-                params={
-                    'surt': 'http://(org,archive,)',
-                    'capture-date': 'today',
-                    'partner': 'baz',
-                }),
-        ])
+        self.assertEqual(
+            mock_request.call_args_list,
+            [
+                call(
+                    "http://localhost/rules/for-request",
+                    params={
+                        "surt": "http://(org,archive,)",
+                        "capture-date": "today",
+                    },
+                ),
+                call(
+                    "http://localhost/rules/for-request",
+                    params={
+                        "surt": "http://(org,archive,)",
+                        "capture-date": "today",
+                        "neg-surt": "foo",
+                    },
+                ),
+                call(
+                    "http://localhost/rules/for-request",
+                    params={
+                        "surt": "http://(org,archive,)",
+                        "capture-date": "today",
+                        "collection": "bar",
+                    },
+                ),
+                call(
+                    "http://localhost/rules/for-request",
+                    params={
+                        "surt": "http://(org,archive,)",
+                        "capture-date": "today",
+                        "partner": "baz",
+                    },
+                ),
+            ],
+        )

--- a/rulesengine_client/tests/test_models.py
+++ b/rulesengine_client/tests/test_models.py
@@ -7,6 +7,7 @@ from datetime import (
 import ipaddr
 from pytz import utc
 import unittest
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -22,64 +23,56 @@ class RuleModelTestCase(unittest.TestCase):
 
     def test_init(self):
         rule = Rule(
-            'http://(com,example,)',
-            'block',
-            neg_surt='http://(com,example,api)',
+            "http://(com,example,)",
+            "block",
+            neg_surt="http://(com,example,api)",
             capture_date={
-                'start': '2000-01-01T12:00:00.000Z',
-                'end': '2001-01-01T12:00:00.000Z',
+                "start": "2000-01-01T12:00:00.000Z",
+                "end": "2001-01-01T12:00:00.000Z",
             },
             retrieve_date={
-                'start': '2000-01-01T12:00:00.000Z',
-                'end': '2001-01-01T12:00:00.000Z',
+                "start": "2000-01-01T12:00:00.000Z",
+                "end": "2001-01-01T12:00:00.000Z",
             },
             ip_range={
-                'start': '4.4.4.4',
-                'end': '8.8.8.8',
+                "start": "4.4.4.4",
+                "end": "8.8.8.8",
             },
             seconds_since_capture=31536000,
-            collection='The Planets',
-            partner='Gustav Holst',
-            protocol='http',
-            subdomain='www',
-            warc_match='.*jupiter.*')
-        self.assertEqual(
-            rule.capture_date['start'],
-            '2000-01-01T12:00:00.000Z')
-        self.assertEqual(
-            rule.capture_date['end'],
-            '2001-01-01T12:00:00.000Z')
-        self.assertEqual(
-            rule.retrieve_date['start'],
-            '2000-01-01T12:00:00.000Z')
-        self.assertEqual(
-            rule.retrieve_date['end'],
-            '2001-01-01T12:00:00.000Z')
-        self.assertEqual(
-            rule.ip_range['start'],
-            ipaddr.IPAddress('4.4.4.4'))
-        self.assertEqual(
-            rule.ip_range['end'],
-            ipaddr.IPAddress('8.8.8.8'))
-        self.assertEqual(
-            rule.protocol,
-            'http')
-        self.assertEqual(
-            rule.subdomain,
-            'www')
+            collection="The Planets",
+            partner="Gustav Holst",
+            protocol="http",
+            subdomain="www",
+            warc_match=".*jupiter.*",
+        )
+        self.assertEqual(rule.capture_date["start"], "2000-01-01T12:00:00.000Z")
+        self.assertEqual(rule.capture_date["end"], "2001-01-01T12:00:00.000Z")
+        self.assertEqual(rule.retrieve_date["start"], "2000-01-01T12:00:00.000Z")
+        self.assertEqual(rule.retrieve_date["end"], "2001-01-01T12:00:00.000Z")
+        self.assertEqual(rule.ip_range["start"], ipaddr.IPAddress("4.4.4.4"))
+        self.assertEqual(rule.ip_range["end"], ipaddr.IPAddress("8.8.8.8"))
+        self.assertEqual(rule.protocol, "http")
+        self.assertEqual(rule.subdomain, "www")
 
-    @patch('rulesengine_client.models.Rule.protocol_applies')
-    @patch('rulesengine_client.models.Rule.subdomain_applies')
-    @patch('rulesengine_client.models.Rule.ip_range_applies')
-    @patch('rulesengine_client.models.Rule.seconds_since_capture_applies')
-    @patch('rulesengine_client.models.Rule.capture_date_applies')
-    @patch('rulesengine_client.models.Rule.retrieve_date_applies')
-    @patch('rulesengine_client.models.Rule.warc_match_applies')
-    def test_applies(self, warc_match_applies, retrieve_date_applies,
-                     capture_date_applies, seconds_since_capture_applies,
-                     ip_range_applies, protocol_applies, subdomain_applies):
-        rule = Rule('http://(com,example,)', 'block')
-        rule.applies('warc', '0.0.0.0', datetime.now(tz=utc))
+    @patch("rulesengine_client.models.Rule.protocol_applies")
+    @patch("rulesengine_client.models.Rule.subdomain_applies")
+    @patch("rulesengine_client.models.Rule.ip_range_applies")
+    @patch("rulesengine_client.models.Rule.seconds_since_capture_applies")
+    @patch("rulesengine_client.models.Rule.capture_date_applies")
+    @patch("rulesengine_client.models.Rule.retrieve_date_applies")
+    @patch("rulesengine_client.models.Rule.warc_match_applies")
+    def test_applies(
+        self,
+        warc_match_applies,
+        retrieve_date_applies,
+        capture_date_applies,
+        seconds_since_capture_applies,
+        ip_range_applies,
+        protocol_applies,
+        subdomain_applies,
+    ):
+        rule = Rule("http://(com,example,)", "block")
+        rule.applies("warc", "0.0.0.0", datetime.now(tz=utc))
         self.assertEqual(warc_match_applies.call_count, 1)
         self.assertEqual(seconds_since_capture_applies.call_count, 1)
         self.assertEqual(protocol_applies.call_count, 1)
@@ -87,8 +80,7 @@ class RuleModelTestCase(unittest.TestCase):
         self.assertEqual(capture_date_applies.call_count, 0)
         self.assertEqual(retrieve_date_applies.call_count, 0)
         self.assertEqual(ip_range_applies.call_count, 0)
-        rule.applies('warc', '0.0.0.0', datetime.now(tz=utc),
-                     server_side_filters=False)
+        rule.applies("warc", "0.0.0.0", datetime.now(tz=utc), server_side_filters=False)
         self.assertEqual(seconds_since_capture_applies.call_count, 2)
         self.assertEqual(protocol_applies.call_count, 2)
         self.assertEqual(subdomain_applies.call_count, 2)
@@ -99,148 +91,150 @@ class RuleModelTestCase(unittest.TestCase):
 
     def test_ip_range_applies(self):
         rule = Rule(
-            'http://(com,example,)',
-            'block',
+            "http://(com,example,)",
+            "block",
             ip_range={
-                'start': '4.4.4.4',
-                'end': '8.8.8.8',
-            })
-        self.assertEqual(rule.ip_range_applies('5.5.5.5'), True)
-        self.assertEqual(rule.ip_range_applies('9.9.9.9'), False)
-        rule = Rule('http://(com,example,)', 'block')
-        self.assertEqual(rule.ip_range_applies('5.5.5.5'), True)
+                "start": "4.4.4.4",
+                "end": "8.8.8.8",
+            },
+        )
+        self.assertEqual(rule.ip_range_applies("5.5.5.5"), True)
+        self.assertEqual(rule.ip_range_applies("9.9.9.9"), False)
+        rule = Rule("http://(com,example,)", "block")
+        self.assertEqual(rule.ip_range_applies("5.5.5.5"), True)
 
     def test_seconds_since_capture_applies(self):
-        rule = Rule(
-            'http://(com,example,)',
-            'block',
-            seconds_since_capture=500)
+        rule = Rule("http://(com,example,)", "block", seconds_since_capture=500)
         now = datetime.now(tz=utc)
         self.assertEqual(
-            rule.seconds_since_capture_applies(datetime2timestamp(now)), True)
+            rule.seconds_since_capture_applies(datetime2timestamp(now)), True
+        )
         self.assertEqual(
-            rule.seconds_since_capture_applies(datetime2timestamp(now - timedelta(days=1))),
-            False)
-        rule = Rule('http://(com,example,)', 'block')
-        self.assertEqual(rule.seconds_since_capture_applies('5.5.5.5'), True)
+            rule.seconds_since_capture_applies(
+                datetime2timestamp(now - timedelta(days=1))
+            ),
+            False,
+        )
+        rule = Rule("http://(com,example,)", "block")
+        self.assertEqual(rule.seconds_since_capture_applies("5.5.5.5"), True)
 
     def test_capture_date_applies(self):
         rule = Rule(
-            'http://(com,example,)',
-            'block',
+            "http://(com,example,)",
+            "block",
             # compare block rule capture dates to timestamps as bytes
             capture_date={
-                'start': '20000101120000'.encode(),
-                'end': '20010101120000'.encode(),
-            })
-        self.assertEqual(
-            rule.capture_date_applies('20000102000000'.encode()),
-            True)
-        self.assertEqual(
-            rule.capture_date_applies('20020102000000'.encode()),
-            False)
-        rule = Rule('http://(com,example,)', 'block')
-        self.assertEqual(
-            rule.capture_date_applies('20000102000000'.encode()),
-            True)
+                "start": "20000101120000".encode(),
+                "end": "20010101120000".encode(),
+            },
+        )
+        self.assertEqual(rule.capture_date_applies("20000102000000".encode()), True)
+        self.assertEqual(rule.capture_date_applies("20020102000000".encode()), False)
+        rule = Rule("http://(com,example,)", "block")
+        self.assertEqual(rule.capture_date_applies("20000102000000".encode()), True)
 
     def test_retrieve_date_applies(self):
         rule = Rule(
-            'http://(com,example,)',
-            'block',
+            "http://(com,example,)",
+            "block",
             retrieve_date={
-                'start': (datetime.now(tz=utc) -
-                          timedelta(days=1)),
-                'end': (datetime.now(tz=utc) + timedelta(days=1)),
-            })
+                "start": (datetime.now(tz=utc) - timedelta(days=1)),
+                "end": (datetime.now(tz=utc) + timedelta(days=1)),
+            },
+        )
         self.assertEqual(rule.retrieve_date_applies(), True)
         self.assertEqual(
-            rule.retrieve_date_applies(
-                retrieve_date=datetime(2000, 1, 1, tzinfo=utc)),
-            False)
+            rule.retrieve_date_applies(retrieve_date=datetime(2000, 1, 1, tzinfo=utc)),
+            False,
+        )
 
     def test_protocol_applies(self):
-        rule = Rule(
-            'http://(com,example,)',
-            'block',
-            protocol='http')
-        self.assertEqual(rule.protocol_applies('http'), True)
-        self.assertEqual(rule.protocol_applies('https'), False)
-        rule = Rule(
-            'http://(com,example,)',
-            'block')
-        self.assertEqual(rule.protocol_applies('https'), True)
+        rule = Rule("http://(com,example,)", "block", protocol="http")
+        self.assertEqual(rule.protocol_applies("http"), True)
+        self.assertEqual(rule.protocol_applies("https"), False)
+        rule = Rule("http://(com,example,)", "block")
+        self.assertEqual(rule.protocol_applies("https"), True)
 
     def test_subdomain_applies(self):
-        rule = Rule(
-            'http://(com,example,)',
-            'block',
-            subdomain='www')
-        self.assertTrue(rule.subdomain_applies('www'))
-        self.assertFalse(rule.subdomain_applies('web'))
-        rule = Rule(
-            'http://(com,example,)',
-            'block')
-        self.assertTrue(rule.subdomain_applies('web'))
+        rule = Rule("http://(com,example,)", "block", subdomain="www")
+        self.assertTrue(rule.subdomain_applies("www"))
+        self.assertFalse(rule.subdomain_applies("web"))
+        rule = Rule("http://(com,example,)", "block")
+        self.assertTrue(rule.subdomain_applies("web"))
+
 
 class RuleCollectionModelTestCase(unittest.TestCase):
 
     def test_init_and_sort(self):
         rules = [
-            Rule('http://(com,example,a)', 'block'),
-            Rule('http://(com,example,c)', 'block'),
-            Rule('http://(com,example,b)', 'block'),
+            Rule("http://(com,example,a)", "block"),
+            Rule("http://(com,example,c)", "block"),
+            Rule("http://(com,example,b)", "block"),
         ]
         collection = RuleCollection(rules)
         self.assertEqual(
             [rule.surt for rule in collection.rules],
             [
-                'http://(com,example,a)',
-                'http://(com,example,b)',
-                'http://(com,example,c)',
-            ])
+                "http://(com,example,a)",
+                "http://(com,example,b)",
+                "http://(com,example,c)",
+            ],
+        )
 
     def test_filter_applicable_rules(self):
-        collection = RuleCollection([
-            Rule('http://(com,example,a)', 'block', warc_match='Holst'),
-            Rule('http://(com,example,c)', 'block', warc_match='Holst'),
-            Rule('http://(com,example,b)', 'block', warc_match='Bizet'),
-        ])
+        collection = RuleCollection(
+            [
+                Rule("http://(com,example,a)", "block", warc_match="Holst"),
+                Rule("http://(com,example,c)", "block", warc_match="Holst"),
+                Rule("http://(com,example,b)", "block", warc_match="Bizet"),
+            ]
+        )
         applicable_rules = collection.filter_applicable_rules(
-            'Holst', server_side_filters=False)
+            "Holst", server_side_filters=False
+        )
         self.assertEqual(
             [rule.surt for rule in applicable_rules.rules],
             [
-                'http://(com,example,a)',
-                'http://(com,example,c)',
-            ])
+                "http://(com,example,a)",
+                "http://(com,example,c)",
+            ],
+        )
 
     def test_allow(self):
-        collection = RuleCollection([
-            Rule('http://(com,', 'block'),
-            Rule('http://(com,example,', 'block'),
-            Rule('http://(com,example,a)', 'allow'),
-        ])
+        collection = RuleCollection(
+            [
+                Rule("http://(com,", "block"),
+                Rule("http://(com,example,", "block"),
+                Rule("http://(com,example,a)", "allow"),
+            ]
+        )
         self.assertEqual(collection.allow(), True)
-        collection = RuleCollection([
-            Rule('http://(com,', 'block'),
-            Rule('http://(com,example,', 'allow'),
-            Rule('http://(com,example,a)', 'block'),
-        ])
+        collection = RuleCollection(
+            [
+                Rule("http://(com,", "block"),
+                Rule("http://(com,example,", "allow"),
+                Rule("http://(com,example,a)", "block"),
+            ]
+        )
         self.assertEqual(collection.allow(), False)
-        collection = RuleCollection([
-            Rule('http://(com,', 'block'),
-            Rule('http://(com,example,', 'allow'),
-            Rule('http://(com,example,a)', 'rewrite-js'),
-        ])
+        collection = RuleCollection(
+            [
+                Rule("http://(com,", "block"),
+                Rule("http://(com,example,", "allow"),
+                Rule("http://(com,example,a)", "rewrite-js"),
+            ]
+        )
         self.assertEqual(collection.allow(), True)
 
     def test_rewrites_only(self):
-        collection = RuleCollection([
-            Rule('http://(com,', 'block'),
-            Rule('http://(com,example,', 'block'),
-            Rule('http://(com,example,a)', 'rewrite-js'),
-        ])
+        collection = RuleCollection(
+            [
+                Rule("http://(com,", "block"),
+                Rule("http://(com,example,", "block"),
+                Rule("http://(com,example,a)", "rewrite-js"),
+            ]
+        )
         rewrites_only = collection.rewrites_only()
-        self.assertEqual([rule.surt for rule in rewrites_only.rules],
-                         ['http://(com,example,a)'])
+        self.assertEqual(
+            [rule.surt for rule in rewrites_only.rules], ["http://(com,example,a)"]
+        )

--- a/rulesengine_client/tests/test_response.py
+++ b/rulesengine_client/tests/test_response.py
@@ -18,54 +18,66 @@ class StubResponse(object):
 class ResponseTestCase(unittest.TestCase):
 
     def test_success(self):
-        response = Response(StubResponse(
-            200,
-            '{"status": "success", "message": "ok", "result": []}'))
+        response = Response(
+            StubResponse(200, '{"status": "success", "message": "ok", "result": []}')
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.status, 'success')
-        self.assertEqual(response.message, 'ok')
+        self.assertEqual(response.status, "success")
+        self.assertEqual(response.message, "ok")
         self.assertEqual(response.result, [])
 
     def test_parse_result_rule(self):
-        response = Response(StubResponse(
-            200,
-            '''{"status": "success", "message": "ok", "result": {
+        response = Response(
+            StubResponse(
+                200,
+                """{"status": "success", "message": "ok", "result": {
                 "surt": "com,",
                 "policy": "block"
-            }}'''))
+            }}""",
+            )
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.status, 'success')
-        self.assertEqual(response.message, 'ok')
-        self.assertEqual(response.rules.rules[0].surt, 'com,')
-        self.assertEqual(response.rules.rules[0].policy, 'block')
+        self.assertEqual(response.status, "success")
+        self.assertEqual(response.message, "ok")
+        self.assertEqual(response.rules.rules[0].surt, "com,")
+        self.assertEqual(response.rules.rules[0].policy, "block")
         self.assertEqual(len(response.rules.rules), 1)
 
     def test_parse_result_rule_collection(self):
-        response = Response(StubResponse(
-            200,
-            '''{"status": "success", "message": "ok", "result": [{
+        response = Response(
+            StubResponse(
+                200,
+                """{"status": "success", "message": "ok", "result": [{
                 "surt": "com,",
                 "policy": "block"
-            }]}'''))
+            }]}""",
+            )
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.status, 'success')
-        self.assertEqual(response.message, 'ok')
-        self.assertEqual(response.rules.rules[0].surt, 'com,')
-        self.assertEqual(response.rules.rules[0].policy, 'block')
+        self.assertEqual(response.status, "success")
+        self.assertEqual(response.message, "ok")
+        self.assertEqual(response.rules.rules[0].surt, "com,")
+        self.assertEqual(response.rules.rules[0].policy, "block")
         self.assertEqual(len(response.rules.rules), 1)
 
     def test_parse_result_malformed_response(self):
         with self.assertRaises(MalformedResponseException):
-            Response(StubResponse(
-                200,
-                '''{"status": "success", "message": "ok",
-                "result": "bad-wolf"}'''))
+            Response(
+                StubResponse(
+                    200,
+                    """{"status": "success", "message": "ok",
+                "result": "bad-wolf"}""",
+                )
+            )
         with self.assertRaises(MalformedResponseException):
-            Response(StubResponse(
-                200,
-                '''{"status": "success", "message": "ok",
-                "result": {"bad-wolf": "oh no"}'''))
+            Response(
+                StubResponse(
+                    200,
+                    """{"status": "success", "message": "ok",
+                "result": {"bad-wolf": "oh no"}""",
+                )
+            )
 
     def test_malformed_response(self):
         with self.assertRaises(MalformedResponseException):
-            Response(StubResponse(500, 'bad-wolf'))
+            Response(StubResponse(500, "bad-wolf"))

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,25 @@ from setuptools import setup
 
 
 setup(
-    name='rulesengine_client',
-    description='Client for interacting with the playback Rules Engine',
-    version='1.2',
+    name="rulesengine_client",
+    description="Client for interacting with the playback Rules Engine",
+    version="1.3b",
     install_requires=[
-        'psycopg2',
-        'python-dateutil',
-        'pytz',
-        'google-re2',
-        'ipaddr',
-        'requests',
+        "psycopg2",
+        "python-dateutil",
+        "pytz",
+        "google-re2",
+        "ipaddr",
+        "requests",
     ],
     tests_require=[
-        'mock',
+        "mock",
     ],
     packages=[
-        'rulesengine_client',
+        "rulesengine_client",
     ],
-    test_suite='rulesengine_client.tests',
-    author='Barbara Miller <barbara@archive.org>, Madison Scott-Clary',
-    author_email='barbara@archive.org',
-    license='GPLv3')
+    test_suite="rulesengine_client.tests",
+    author="Barbara Miller <barbara@archive.org>, Madison Scott-Clary",
+    author_email="barbara@archive.org",
+    license="GPLv3",
+)


### PR DESCRIPTION
Adds support for HTTP status codes as a rule selector. This supports the creation of rules like "block all 500s for a given SURT".